### PR TITLE
Update the pre-exit hook to clean up worktree dirs properly

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -2,5 +2,5 @@
 
 set -e -o pipefail
 
-# Build directories are ephemeral, remove it when the job is finished.
-rm -rf "$BUILDKITE_BUILD_CHECKOUT_PATH"
+# Remove both the worktree checkout and the corresponding directory from .git/worktrees in the shared git dir
+git -C "$BUILDKITE_BUILD_CHECKOUT_PATH" worktree remove .


### PR DESCRIPTION
We noticed that the previously cleanup mechanism only cleaned up the worktree checkout dirs and not all the worktree metadata stored in the shared `.git` dir. This cleans up both.

cc @juliahw